### PR TITLE
Issue #31 - UTF-8 symbols and spaces in image URL

### DIFF
--- a/UniversalImageLoader/src/com/nostra13/universalimageloader/core/ImageLoadingInfo.java
+++ b/UniversalImageLoader/src/com/nostra13/universalimageloader/core/ImageLoadingInfo.java
@@ -25,7 +25,7 @@ final class ImageLoadingInfo {
 	final ImageLoadingListener listener;
 
 	public ImageLoadingInfo(String uri, ImageView imageView, ImageSize targetSize, DisplayImageOptions options, ImageLoadingListener listener) {
-		this.uri = Uri.encode(uri, "@#&=+-_.,:?()/%");
+		this.uri = Uri.encode(uri, "@#&=*+-_.,:!?()/~'%");
 		this.imageView = imageView;
 		this.targetSize = targetSize;
 		this.options = options;


### PR DESCRIPTION
Issue #31

Fixed issue with UTF-8 symbols and spaces in image URL as described in this thread:
https://github.com/nostra13/Android-Universal-Image-Loader/issues/31
