### PR TITLE
There is a small improvement that should prevent showing a wrong bitmap in the recycled view

### DIFF
--- a/UniversalImageLoader/src/com/nostra13/universalimageloader/core/DisplayBitmapTask.java
+++ b/UniversalImageLoader/src/com/nostra13/universalimageloader/core/DisplayBitmapTask.java
@@ -18,16 +18,23 @@ final class DisplayBitmapTask implements Runnable {
 	private final ImageView imageView;
 	private final BitmapDisplayer bitmapDisplayer;
 	private final ImageLoadingListener listener;
+	private final String memoryCacheKey;
 
-	public DisplayBitmapTask(Bitmap bitmap, ImageView imageView, BitmapDisplayer bitmapDisplayer, ImageLoadingListener listener) {
+	public DisplayBitmapTask(Bitmap bitmap, ImageView imageView, BitmapDisplayer bitmapDisplayer, ImageLoadingListener listener, String memoryCacheKey) {
 		this.bitmap = bitmap;
 		this.imageView = imageView;
 		this.bitmapDisplayer = bitmapDisplayer;
 		this.listener = listener;
+		this.memoryCacheKey = memoryCacheKey;
 	}
 
 	public void run() {
-		Bitmap displayedBitmap = bitmapDisplayer.display(bitmap, imageView);
-		listener.onLoadingComplete(displayedBitmap);
+		String currentCacheKey = ImageLoader.getInstance().getLoadingUriForView(imageView);
+		if (memoryCacheKey.equals(currentCacheKey)) {
+			Bitmap displayedBitmap = bitmapDisplayer.display(bitmap, imageView);
+			listener.onLoadingComplete(displayedBitmap);
+		} else {
+			listener.onLoadingCancelled();
+		}
 	}
 }

--- a/UniversalImageLoader/src/com/nostra13/universalimageloader/core/LoadAndDisplayImageTask.java
+++ b/UniversalImageLoader/src/com/nostra13/universalimageloader/core/LoadAndDisplayImageTask.java
@@ -90,7 +90,7 @@ final class LoadAndDisplayImageTask implements Runnable {
 		if (configuration.loggingEnabled) Log.i(ImageLoader.TAG, String.format(LOG_DISPLAY_IMAGE_IN_IMAGEVIEW, imageLoadingInfo.memoryCacheKey));
 
 		DisplayBitmapTask displayBitmapTask = new DisplayBitmapTask(bmp, imageLoadingInfo.imageView, imageLoadingInfo.options.getDisplayer(),
-				imageLoadingInfo.listener);
+				imageLoadingInfo.listener, imageLoadingInfo.memoryCacheKey);
 		handler.post(displayBitmapTask);
 	}
 


### PR DESCRIPTION
Hi,

Sometimes when I scroll a ListView, wrong images appear in recycled views. These images appear just for a moment until actual images are loaded. It happens quite rarely, but it is still very irritating.

Here is the simple scheme of what is actually happening in the code:
1. Some image is completely loaded in a background thread, it is checked for actuality and a new DisplayBitmapTask is posted to the UI.
2. Some views are recycled. Among them is a view that is still linked with the image from item 1. At this point the image becomes not actual.
3. The DisplayBitmapTask from item 1 is finally executed and unfortunately it shows the wrong image.

So I added a simple actuality check into the DisplayBitmapTask. Therefore there is no single chance for an inactual image to be shown.  Please review this fix and apply it if you want.
