### PR TITLE
Add getCachedFileOnDiscIfExist for some flexibility

### DIFF
--- a/UniversalImageLoader/src/com/nostra13/universalimageloader/core/ImageLoader.java
+++ b/UniversalImageLoader/src/com/nostra13/universalimageloader/core/ImageLoader.java
@@ -1,5 +1,6 @@
 package com.nostra13.universalimageloader.core;
 
+import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
@@ -370,6 +371,17 @@ public class ImageLoader {
 		if (configuration != null) {
 			configuration.memoryCache.clear();
 		}
+	}
+	
+	/**
+	 * Return the file corresponding to uri if cached on disk.
+	 */
+	public File getCachedFileOnDiscIfExist(String uri){
+	    File file = configuration.discCache.get(uri);
+	    if (!file.exists()){
+	        return null;
+	    }
+	    return file;
 	}
 
 	/** Returns disc cache */


### PR DESCRIPTION
I have added the method getCachedFileOnDiscIfExist() in ImageLoader.
This provide a way to test if an url has been cached, and offer a direct link to the file.

This is useful in my case because I have a background thread that shows Android notifications  with a big picture only If the picture is already in cache or a resource drawable otherwise.

Below how I am using this method

``` java
final File file = ImageLoader.getInstance().getCachedFileOnDiscIfExist(url);
if (!file.exists()) {
    return null;
}
final Resources res = mContext.getResources();
final int idealIconHeight =
                res.getDimensionPixelSize(android.R.dimen.notification_large_icon_height);
final int idealIconWidth =
                res.getDimensionPixelSize(android.R.dimen.notification_large_icon_width);

return Utility.decodeSampledBitmapFromFile(file.getPath(), idealIconWidth,
                idealIconHeight);
```
