### PR TITLE
allow callers to specify their own Handler

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/DisplayImageOptions.java
+++ b/library/src/com/nostra13/universalimageloader/core/DisplayImageOptions.java
@@ -17,6 +17,7 @@ package com.nostra13.universalimageloader.core;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory.Options;
+import android.os.Handler;
 import android.widget.ImageView;
 
 import com.nostra13.universalimageloader.core.assist.ImageScaleType;
@@ -70,6 +71,7 @@ public final class DisplayImageOptions {
 	private final BitmapProcessor preProcessor;
 	private final BitmapProcessor postProcessor;
 	private final BitmapDisplayer displayer;
+	private final Handler handler;
 
 	private DisplayImageOptions(Builder builder) {
 		stubImage = builder.stubImage;
@@ -85,6 +87,7 @@ public final class DisplayImageOptions {
 		preProcessor = builder.preProcessor;
 		postProcessor = builder.postProcessor;
 		displayer = builder.displayer;
+		handler = builder.handler;
 	}
 
 	public boolean shouldShowStubImage() {
@@ -163,6 +166,10 @@ public final class DisplayImageOptions {
 		return displayer;
 	}
 
+	public Handler getHandler() {
+		return (handler == null ? new Handler() : handler);
+	}
+
 	/**
 	 * Builder for {@link DisplayImageOptions}
 	 * 
@@ -182,6 +189,7 @@ public final class DisplayImageOptions {
 		private BitmapProcessor preProcessor = null;
 		private BitmapProcessor postProcessor = null;
 		private BitmapDisplayer displayer = DefaultConfigurationFactory.createBitmapDisplayer();
+		private Handler handler = null;
 
 		public Builder() {
 			decodingOptions.inPurgeable = true;
@@ -305,6 +313,14 @@ public final class DisplayImageOptions {
 			return this;
 		}
 
+		/**
+		 * Sets custom Handler for controlling running of completion-posting jobs.
+		 */
+		public Builder handler(Handler handler) {
+			this.handler = handler;
+			return this;
+		}
+
 		/** Sets all options equal to incoming options */
 		public Builder cloneFrom(DisplayImageOptions options) {
 			stubImage = options.stubImage;
@@ -320,6 +336,7 @@ public final class DisplayImageOptions {
 			preProcessor = options.preProcessor;
 			postProcessor = options.postProcessor;
 			displayer = options.displayer;
+			handler = options.handler;
 			return this;
 		}
 

--- a/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
+++ b/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
@@ -227,7 +227,7 @@ public class ImageLoader {
 
 			if (options.shouldPostProcess()) {
 				ImageLoadingInfo imageLoadingInfo = new ImageLoadingInfo(uri, imageView, targetSize, options, listener, engine.getLockForUri(uri));
-				ProcessAndDisplayImageTask displayTask = new ProcessAndDisplayImageTask(engine, bmp, imageLoadingInfo, new Handler());
+				ProcessAndDisplayImageTask displayTask = new ProcessAndDisplayImageTask(engine, bmp, imageLoadingInfo, options.getHandler());
 				engine.submit(displayTask);
 			} else {
 				options.getDisplayer().display(bmp, imageView);
@@ -243,7 +243,7 @@ public class ImageLoader {
 			}
 
 			ImageLoadingInfo imageLoadingInfo = new ImageLoadingInfo(uri, imageView, targetSize, options, listener, engine.getLockForUri(uri));
-			LoadAndDisplayImageTask displayTask = new LoadAndDisplayImageTask(engine, imageLoadingInfo, new Handler());
+			LoadAndDisplayImageTask displayTask = new LoadAndDisplayImageTask(engine, imageLoadingInfo, options.getHandler());
 			engine.submit(displayTask);
 		}
 	}


### PR DESCRIPTION
It's probably pretty unusual, but sometimes we need to override the Image Loader's behavior of calling the no-argument `new Handler()` constructor to create a `Handler` for calling the `LoadAndDisplayImageTask`. The patch here allows callers to set their own `Handler` in the `DisplayImageOptions` if needed.

This is probably primarily useful if you're using `loadImage()` rather than `displayImage()`.
