### PR TITLE
Possibility to cache preprocessed image on disc

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/DisplayImageOptions.java
+++ b/library/src/com/nostra13/universalimageloader/core/DisplayImageOptions.java
@@ -65,6 +65,7 @@ public final class DisplayImageOptions {
 	private final boolean resetViewBeforeLoading;
 	private final boolean cacheInMemory;
 	private final boolean cacheOnDisc;
+    private final boolean cachePreProcessedImageOnDisc;
 	private final ImageScaleType imageScaleType;
 	private final Options decodingOptions;
 	private final int delayBeforeLoading;
@@ -81,6 +82,7 @@ public final class DisplayImageOptions {
 		resetViewBeforeLoading = builder.resetViewBeforeLoading;
 		cacheInMemory = builder.cacheInMemory;
 		cacheOnDisc = builder.cacheOnDisc;
+        cachePreProcessedImageOnDisc = builder.cachePreProcessedImageOnDisc;
 		imageScaleType = builder.imageScaleType;
 		decodingOptions = builder.decodingOptions;
 		delayBeforeLoading = builder.delayBeforeLoading;
@@ -139,7 +141,11 @@ public final class DisplayImageOptions {
 		return cacheOnDisc;
 	}
 
-	public ImageScaleType getImageScaleType() {
+    public boolean shouldCachePreProcessedImageOnDisc() {
+        return cachePreProcessedImageOnDisc;
+    }
+
+    public ImageScaleType getImageScaleType() {
 		return imageScaleType;
 	}
 
@@ -183,6 +189,7 @@ public final class DisplayImageOptions {
 		private boolean resetViewBeforeLoading = false;
 		private boolean cacheInMemory = false;
 		private boolean cacheOnDisc = false;
+        private boolean cachePreProcessedImageOnDisc = false;
 		private ImageScaleType imageScaleType = ImageScaleType.IN_SAMPLE_POWER_OF_2;
 		private Options decodingOptions = new Options();
 		private int delayBeforeLoading = 0;
@@ -246,6 +253,14 @@ public final class DisplayImageOptions {
 			cacheOnDisc = true;
 			return this;
 		}
+
+        /** The loaded image will be pre processed and the processed version will be cached on disc.
+         * If this option is not activated, the original image will be cached on disc.
+         */
+        public Builder cacheOnDiscPreProcessedImage(){
+            cachePreProcessedImageOnDisc = true;
+            return this;
+        }
 
 		/**
 		 * Sets {@linkplain ImageScaleType scale type} for decoding image. This parameter is used while define scale
@@ -332,6 +347,7 @@ public final class DisplayImageOptions {
 			resetViewBeforeLoading = options.resetViewBeforeLoading;
 			cacheInMemory = options.cacheInMemory;
 			cacheOnDisc = options.cacheOnDisc;
+            cachePreProcessedImageOnDisc = options.cachePreProcessedImageOnDisc;
 			imageScaleType = options.imageScaleType;
 			decodingOptions = options.decodingOptions;
 			delayBeforeLoading = options.delayBeforeLoading;

--- a/library/src/com/nostra13/universalimageloader/core/LoadAndDisplayImageTask.java
+++ b/library/src/com/nostra13/universalimageloader/core/LoadAndDisplayImageTask.java
@@ -15,12 +15,7 @@
  *******************************************************************************/
 package com.nostra13.universalimageloader.core;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -136,12 +131,17 @@ final class LoadAndDisplayImageTask implements Runnable {
 
 				if (checkTaskIsNotActual() || checkTaskIsInterrupted()) return;
 
-				if (options.shouldPreProcess()) {
+				if (options.shouldPreProcess() && !(loadedFrom == LoadedFrom.DISC_CACHE && options.shouldCachePreProcessedImageOnDisc())) {
 					log(LOG_PREPROCESS_IMAGE);
 					bmp = options.getPreProcessor().process(bmp);
 					if (bmp == null) {
 						L.w(WARNING_PRE_PROCESSOR_NULL);
 					}
+                    else {
+                        if(options.shouldCachePreProcessedImageOnDisc()){
+                            cachePreProcessedImageOnDisc(bmp);
+                        }
+                    }
 				}
 
 				if (bmp != null && options.isCacheInMemory()) {
@@ -171,7 +171,28 @@ final class LoadAndDisplayImageTask implements Runnable {
 		handler.post(displayBitmapTask);
 	}
 
-	/**
+    private void cachePreProcessedImageOnDisc(Bitmap bmp) {
+        File targetFile = getImageFileInDiscCache();
+        OutputStream os = null;
+        try {
+            os = new BufferedOutputStream(new FileOutputStream(targetFile), BUFFER_SIZE);
+            boolean savedSuccessfully = bmp.compress(Bitmap.CompressFormat.PNG, 0, os);
+            if(savedSuccessfully){
+                configuration.discCache.put(uri, targetFile);
+            }
+
+        } catch (FileNotFoundException e) {
+            L.e(e);
+        }
+        finally {
+            if(os != null){
+                IoUtils.closeSilently(os);
+            }
+        }
+
+    }
+
+    /**
 	 * @return true - if task should be interrupted; false - otherwise
 	 */
 	private boolean waitIfPaused() {


### PR DESCRIPTION
Hello,

As promised here https://github.com/nostra13/Android-Universal-Image-Loader/issues/309, I've implemented the functionality and made this pull request.

I've tested this with the app I'm developing. I have a listview that is loaded and paginated from the web. When I loaded too many items, each one with its image (some of the images was repeating), the memory cache was becoming full quickly and it was starting to preprocess all the images again, when I scroll up. It was consuming much CPU and memory... and also giving the user the impression that the image was being loaded again. Now, it's putting the preprocessed image on disc cache. So, it's preprocessing the image just one time and it saved me a lot of CPU and memory. At the moment, I tested to load about 800 items in the ListView. Since some images are repeating, I think it's about 300 unique images in the ListView. When I scroll down, more items are loaded. If I scroll up until reach the top, I see all the images quickly, as if it was loaded instantly. And it's scrolling smoothly.

The way I've implemented, it's not going to break any code that uses this new version. I've included a new option called cachePreProcessedImageOnDisc in the DisplayImageOptions. I think that the user usually would use either cacheOnDisc or cachePreProcessedImageOnDisc. If both are activated, the original image will be loaded from the network to the file and then the file will be overwritten with the preprocessed image.

I hope it's useful.
