### PR TITLE
fix error messages when checking null objects.

### DIFF
--- a/library/src/com/nostra13/universalimageloader/cache/disc/BaseDiscCache.java
+++ b/library/src/com/nostra13/universalimageloader/cache/disc/BaseDiscCache.java
@@ -42,10 +42,10 @@ public abstract class BaseDiscCache implements DiscCacheAware {
 
 	public BaseDiscCache(File cacheDir, FileNameGenerator fileNameGenerator) {
 		if (cacheDir == null) {
-			throw new IllegalArgumentException("cacheDir" + ERROR_ARG_NULL);
+			throw new IllegalArgumentException(String.format(ERROR_ARG_NULL, "cacheDir"));
 		}
 		if (fileNameGenerator == null) {
-			throw new IllegalArgumentException("fileNameGenerator" + ERROR_ARG_NULL);
+			throw new IllegalArgumentException(String.format(ERROR_ARG_NULL, "fileNameGenerator"));
 		}
 
 		this.cacheDir = cacheDir;


### PR DESCRIPTION
When a null value is passed to a constructor of BaseDiscCache, the message of exception is as following.

```
java.lang.IllegalArgumentException: cacheDir"%s" argument must be not null
    at com.nostra13.universalimageloader.cache.disc.BaseDiscCache.<init>(BaseDiscCache.java:45)
```

As I guess, it is the original intention to show that

```
java.lang.NullPointerException: "cacheDir" argument must be not null
```
