### PR TITLE
Properly decode the URI-encoded file paths.

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/download/BaseImageDownloader.java
+++ b/library/src/com/nostra13/universalimageloader/core/download/BaseImageDownloader.java
@@ -138,7 +138,7 @@ public class BaseImageDownloader implements ImageDownloader {
 	 * @throws IOException if some I/O error occurs reading from file system
 	 */
 	protected InputStream getStreamFromFile(String imageUri, Object extra) throws IOException {
-		String filePath = Scheme.FILE.crop(imageUri);
+		String filePath = Uri.parse(imageUri).getPath();
 		return new BufferedInputStream(new FileInputStream(filePath), BUFFER_SIZE);
 	}
 


### PR DESCRIPTION
This fixes loading from paths with spaces encoded as %20.
