### PR TITLE
Correct some comment of LargestLimitedMemoryCache

### DIFF
--- a/library/src/com/nostra13/universalimageloader/cache/memory/impl/LargestLimitedMemoryCache.java
+++ b/library/src/com/nostra13/universalimageloader/cache/memory/impl/LargestLimitedMemoryCache.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 /**
  * Limited {@link Bitmap bitmap} cache. Provides {@link Bitmap bitmaps} storing. Size of all stored bitmaps will not to
- * exceed size limit. When cache reaches limit size then the bitmap which used the least frequently is deleted from
+ * exceed size limit. When cache reaches limit size then the bitmap which has the largest size is deleted from
  * cache.<br />
  * <br />
  * <b>NOTE:</b> This cache uses strong and weak references for stored Bitmaps. Strong references - for limited count of
@@ -39,8 +39,8 @@ import java.util.Set;
  */
 public class LargestLimitedMemoryCache extends LimitedMemoryCache<String, Bitmap> {
 	/**
-	 * Contains strong references to stored objects (keys) and last object usage date (in milliseconds). If hard cache
-	 * size will exceed limit then object with the least frequently usage is deleted (but it continue exist at
+	 * Contains strong references to stored objects (keys) and sizes of the objects. If hard cache
+	 * size will exceed limit then object with the largest size is deleted (but it continue exist at
 	 * {@link #softMap} and can be collected by GC at any time)
 	 */
 	private final Map<Bitmap, Integer> valueSizes = Collections.synchronizedMap(new HashMap<Bitmap, Integer>());


### PR DESCRIPTION
Correct some comment of LargestLimitedMemoryCache.
The comment which describes LargestLimitedMemoryCache was the same as
UsingFreqLimitedMemoryCache's.
