### PR TITLE
Add basic gradle library support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.7.+'
+    }
+}
+
+allprojects {
+    group = 'com.nostra13.universalimageloader'
+    version = '1.9.2-SNAPSHOT'
+
+    repositories {
+        mavenCentral()
+    }
+
+    tasks.withType(Compile) {
+        options.encoding = "UTF-8"
+    }
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'android-library'
+
+android {
+    compileSdkVersion 16
+	buildToolsVersion "19.0.1"
+
+	sourceSets {
+		main {
+			manifest.srcFile 'AndroidManifest.xml'
+			java.srcDirs = ['src']
+			resources.srcDirs = ['src']
+			aidl.srcDirs = ['src']
+			renderscript.srcDirs = ['src']
+			res.srcDirs = ['res']
+			assets.srcDirs = ['assets']
+		}
+
+		instrumentTest.setRoot('tests')
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include 'library'


### PR DESCRIPTION
I still can't get it to work, I don't know why. Maybe it's because of the directory layout. I tried to follow the android gradle docs, taking ABS as a reference.
