### PR TITLE
Fixing bug of "smirreled" corners/decentralized image when using RoundedBitmapDisplayer and the image was resized to fit the ImageView

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/display/RoundedBitmapDisplayer.java
+++ b/library/src/com/nostra13/universalimageloader/core/display/RoundedBitmapDisplayer.java
@@ -17,6 +17,7 @@ package com.nostra13.universalimageloader.core.display;
 
 import android.graphics.*;
 import android.graphics.drawable.Drawable;
+
 import com.nostra13.universalimageloader.core.assist.LoadedFrom;
 import com.nostra13.universalimageloader.core.imageaware.ImageAware;
 import com.nostra13.universalimageloader.core.imageaware.ImageViewAware;
@@ -64,7 +65,8 @@ public class RoundedBitmapDisplayer implements BitmapDisplayer {
 		protected final float cornerRadius;
 		protected final int margin;
 
-		protected final RectF mRect = new RectF();
+		protected final RectF mRect = new RectF(),
+				mBitmapRect;
 		protected final BitmapShader bitmapShader;
 		protected final Paint paint;
 
@@ -73,7 +75,8 @@ public class RoundedBitmapDisplayer implements BitmapDisplayer {
 			this.margin = margin;
 
 			bitmapShader = new BitmapShader(bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
-
+			mBitmapRect = new RectF (margin, margin, bitmap.getWidth() - margin, bitmap.getHeight() - margin);
+			
 			paint = new Paint();
 			paint.setAntiAlias(true);
 			paint.setShader(bitmapShader);
@@ -83,6 +86,12 @@ public class RoundedBitmapDisplayer implements BitmapDisplayer {
 		protected void onBoundsChange(Rect bounds) {
 			super.onBoundsChange(bounds);
 			mRect.set(margin, margin, bounds.width() - margin, bounds.height() - margin);
+			
+			// Resize the original bitmap to fit the new bound
+			Matrix shaderMatrix = new Matrix();
+			shaderMatrix.setRectToRect(mBitmapRect, mRect, Matrix.ScaleToFit.FILL);
+			bitmapShader.setLocalMatrix(shaderMatrix);
+			
 		}
 
 		@Override


### PR DESCRIPTION
Whenever I used RoundedBitmapDisplayer with an image that should be scaled, its borders got distorted. I've added some code to correctly translate the image from its original size to the ImageView bounds.
