### PR TITLE
ContentImageDecoder: Allow consider contentUri orientation and discCache is not required

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/decode/BaseImageDecoder.java
+++ b/library/src/com/nostra13/universalimageloader/core/decode/BaseImageDecoder.java
@@ -109,7 +109,7 @@ public class BaseImageDecoder implements ImageDecoder {
 		return new ImageFileInfo(new ImageSize(options.outWidth, options.outHeight, exif.rotation), exif);
 	}
 
-	protected boolean canDefineExifParams(String imageUri, String mimeType) {
+	private boolean canDefineExifParams(String imageUri, String mimeType) {
 		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR && "image/jpeg".equalsIgnoreCase(mimeType) && Scheme
 				.ofUri(imageUri) == Scheme.FILE;
 	}


### PR DESCRIPTION
 #439
