### PR TITLE
do not used bitmap from memory cache if the bitmap is recycled

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/LoadAndDisplayImageTask.java
+++ b/library/src/com/nostra13/universalimageloader/core/LoadAndDisplayImageTask.java
@@ -131,7 +131,7 @@ final class LoadAndDisplayImageTask implements Runnable, IoUtils.CopyListener {
 			checkTaskNotActual();
 
 			bmp = configuration.memoryCache.get(memoryCacheKey);
-			if (bmp == null) {
+			if (bmp == null || bmp.isRecycled()) {
 				bmp = tryLoadBitmap();
 				if (bmp == null) return; // listener callback already was fired
 


### PR DESCRIPTION
I try to call Bitmap.recyle() method, which bitmap is loaded by Android-Universal-Image-Loader.

And I load this bitmap with Android-Universal-Image-Loader again.

Then my app crash.
