### PR TITLE
Add force to refresh flag and processing logic

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/DisplayImageOptions.java
+++ b/library/src/com/nostra13/universalimageloader/core/DisplayImageOptions.java
@@ -82,12 +82,11 @@ public final class DisplayImageOptions {
 	private final BitmapProcessor postProcessor;
 	private final BitmapDisplayer displayer;
 	private final Handler handler;
-	private final boolean isSyncLoading;
-	
-	private final boolean isForcedrefresh;
+	private final boolean isSyncLoading;	
+	private final boolean isForcedToRefresh;
 
 	private DisplayImageOptions(Builder builder) {
-		isForcedrefresh = builder.isForcedrefresh;
+		isForcedToRefresh = builder.isForcedrefresh;
 		imageResOnLoading = builder.imageResOnLoading;
 		imageResForEmptyUri = builder.imageResForEmptyUri;
 		imageResOnFail = builder.imageResOnFail;
@@ -153,8 +152,8 @@ public final class DisplayImageOptions {
 		return cacheInMemory;
 	}
 	
-	public boolean isForcedrefresh() {
-		return isForcedrefresh;
+	public boolean isForcedToRefresh() {
+		return isForcedToRefresh;
 	}
 
 	public boolean isCacheOnDisk() {
@@ -424,7 +423,8 @@ public final class DisplayImageOptions {
 			return this;
 		}
 		
-		public Builder isForcedrefresh(boolean force) {
+		/** Sets whether ImageLoader will force to load mage from the original uri and refresh the cache when success */
+		public Builder isForcedToRefresh(boolean force) {
 			this.isForcedrefresh = force;
 			return this;
 		}

--- a/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
+++ b/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
@@ -234,8 +234,11 @@ public class ImageLoader {
 
 		listener.onLoadingStarted(uri, imageAware.getWrappedView());
 
-		Bitmap bmp = configuration.memoryCache.get(memoryCacheKey);
-		if (!options.isForcedrefresh() && bmp != null && !bmp.isRecycled()) {
+		Bitmap bmp = null;
+		if (!options.isForcedToRefresh()) {
+			bmp = configuration.memoryCache.get(memoryCacheKey);
+		}
+		if (!options.isForcedToRefresh() && bmp != null && !bmp.isRecycled()) {
 			L.d(LOG_LOAD_IMAGE_FROM_MEMORY_CACHE, memoryCacheKey);
 
 			if (options.shouldPostProcess()) {


### PR DESCRIPTION
when a image is already cached, i want to refresh it from the same uri, but do not want to delete the cache first, because the new operation may be failed, and i want to keep the old cache, so, if success, then refresh the cache normally
