### PR TITLE
optionally do not read network response if server returned non-200 code

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/download/BaseImageDownloader.java
+++ b/library/src/com/nostra13/universalimageloader/core/download/BaseImageDownloader.java
@@ -65,17 +65,20 @@ public class BaseImageDownloader implements ImageDownloader {
 	protected final Context context;
 	protected final int connectTimeout;
 	protected final int readTimeout;
+	/**
+	 * Whether read stream if server returned non-200 response
+	 */
+	protected final boolean readOnError;
 
 	public BaseImageDownloader(Context context) {
-		this.context = context.getApplicationContext();
-		this.connectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT;
-		this.readTimeout = DEFAULT_HTTP_READ_TIMEOUT;
+		this(context.getApplicationContext(), DEFAULT_HTTP_CONNECT_TIMEOUT, DEFAULT_HTTP_READ_TIMEOUT, false);
 	}
 
-	public BaseImageDownloader(Context context, int connectTimeout, int readTimeout) {
+	public BaseImageDownloader(Context context, int connectTimeout, int readTimeout, boolean readOnError) {
 		this.context = context.getApplicationContext();
 		this.connectTimeout = connectTimeout;
 		this.readTimeout = readTimeout;
+		this.readOnError = readOnError;
 	}
 
 	@Override
@@ -119,6 +122,9 @@ public class BaseImageDownloader implements ImageDownloader {
 
 		InputStream imageStream;
 		try {
+			if (conn.getResponseCode() != 200 && !readOnError) {
+				throw new IOException("Unable to retrieve image. Response code: " + conn.getResponseCode());
+			}
 			imageStream = conn.getInputStream();
 		} catch (IOException e) {
 			// Read all data to allow reuse connection (http://bit.ly/1ad35PY)


### PR DESCRIPTION
Problem:
Sometimes media server does not have image file or has a problem with retrieving this image it returns some default image with HTTP status code `404` or `50x` accordingly. By default library do not recognize any problem as long as there's response body. Default image is cached as a normal image and the only way to get back normal image is to clear cache and retry request in sometime.

Solution:
Do not read response body if HTTP status code is not `200`. No erratic images in cache, uses fail image from `showImageOnFail` if present. PROFIT!

P.S. I've made it optional but left it by default on as I believe current behavior is erratic.
