### PR TITLE
display image added judge whether it's first display

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/DisplayBitmapTask.java
+++ b/library/src/com/nostra13/universalimageloader/core/DisplayBitmapTask.java
@@ -67,6 +67,7 @@ final class DisplayBitmapTask implements Runnable {
 			listener.onLoadingCancelled(imageUri, imageAware.getWrappedView());
 		} else {
 			L.d(LOG_DISPLAY_IMAGE_IN_IMAGEAWARE, loadedFrom, memoryCacheKey);
+			displayer.judgeFirstDisplay(imageUri, imageAware);
 			displayer.display(bitmap, imageAware, loadedFrom);
 			engine.cancelDisplayTaskFor(imageAware);
 			listener.onLoadingComplete(imageUri, imageAware.getWrappedView(), bitmap);

--- a/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
+++ b/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
@@ -249,6 +249,7 @@ public class ImageLoader {
 					engine.submit(displayTask);
 				}
 			} else {
+				options.getDisplayer().judgeFirstDisplay(uri, imageAware);
 				options.getDisplayer().display(bmp, imageAware, LoadedFrom.MEMORY_CACHE);
 				listener.onLoadingComplete(uri, imageAware.getWrappedView(), bmp);
 			}

--- a/library/src/com/nostra13/universalimageloader/core/display/BitmapDisplayer.java
+++ b/library/src/com/nostra13/universalimageloader/core/display/BitmapDisplayer.java
@@ -40,4 +40,8 @@ public interface BitmapDisplayer {
 	 * @param loadedFrom Source of loaded image
 	 */
 	void display(Bitmap bitmap, ImageAware imageAware, LoadedFrom loadedFrom);
+	
+	void judgeFirstDisplay(String uri, ImageAware imageAware);
+	
+	boolean isFirstDisplay();
 }

--- a/library/src/com/nostra13/universalimageloader/core/display/FadeInBitmapDisplayer.java
+++ b/library/src/com/nostra13/universalimageloader/core/display/FadeInBitmapDisplayer.java
@@ -29,7 +29,7 @@ import com.nostra13.universalimageloader.core.imageaware.ImageAware;
  * @author Sergey Tarasevich (nostra13[at]gmail[dot]com), Daniel Martí
  * @since 1.6.4
  */
-public class FadeInBitmapDisplayer implements BitmapDisplayer {
+public class FadeInBitmapDisplayer extends SimpleBitmapDisplayer {
 
 	private final int durationMillis;
 
@@ -58,14 +58,16 @@ public class FadeInBitmapDisplayer implements BitmapDisplayer {
 		this.animateFromMemory = animateFromMemory;
 	}
 
-	@Override
 	public void display(Bitmap bitmap, ImageAware imageAware, LoadedFrom loadedFrom) {
+		super.display(bitmap, imageAware, loadedFrom);
 		imageAware.setImageBitmap(bitmap);
 
-		if ((animateFromNetwork && loadedFrom == LoadedFrom.NETWORK) ||
-				(animateFromDisk && loadedFrom == LoadedFrom.DISC_CACHE) ||
-				(animateFromMemory && loadedFrom == LoadedFrom.MEMORY_CACHE)) {
-			animate(imageAware.getWrappedView(), durationMillis);
+		if (isFirstDisplay()) {
+			if ((animateFromNetwork && loadedFrom == LoadedFrom.NETWORK) ||
+					(animateFromDisk && loadedFrom == LoadedFrom.DISC_CACHE) ||
+					(animateFromMemory && loadedFrom == LoadedFrom.MEMORY_CACHE)) {
+				animate(imageAware.getWrappedView(), durationMillis);
+			}
 		}
 	}
 

--- a/library/src/com/nostra13/universalimageloader/core/display/RoundedBitmapDisplayer.java
+++ b/library/src/com/nostra13/universalimageloader/core/display/RoundedBitmapDisplayer.java
@@ -38,7 +38,7 @@ import com.nostra13.universalimageloader.core.imageaware.ImageViewAware;
  * @author Sergey Tarasevich (nostra13[at]gmail[dot]com)
  * @since 1.5.6
  */
-public class RoundedBitmapDisplayer implements BitmapDisplayer {
+public class RoundedBitmapDisplayer extends SimpleBitmapDisplayer {
 
 	protected final int cornerRadius;
 	protected final int margin;
@@ -54,6 +54,7 @@ public class RoundedBitmapDisplayer implements BitmapDisplayer {
 
 	@Override
 	public void display(Bitmap bitmap, ImageAware imageAware, LoadedFrom loadedFrom) {
+		super.display(bitmap, imageAware, loadedFrom);
 		if (!(imageAware instanceof ImageViewAware)) {
 			throw new IllegalArgumentException("ImageAware should wrap ImageView. ImageViewAware is expected.");
 		}

--- a/library/src/com/nostra13/universalimageloader/core/display/RoundedVignetteBitmapDisplayer.java
+++ b/library/src/com/nostra13/universalimageloader/core/display/RoundedVignetteBitmapDisplayer.java
@@ -43,6 +43,7 @@ public class RoundedVignetteBitmapDisplayer extends RoundedBitmapDisplayer {
 
 	@Override
 	public void display(Bitmap bitmap, ImageAware imageAware, LoadedFrom loadedFrom) {
+		super.display(bitmap, imageAware, loadedFrom);
 		if (!(imageAware instanceof ImageViewAware)) {
 			throw new IllegalArgumentException("ImageAware should wrap ImageView. ImageViewAware is expected.");
 		}

--- a/library/src/com/nostra13/universalimageloader/core/display/SimpleBitmapDisplayer.java
+++ b/library/src/com/nostra13/universalimageloader/core/display/SimpleBitmapDisplayer.java
@@ -16,18 +16,38 @@
 package com.nostra13.universalimageloader.core.display;
 
 import android.graphics.Bitmap;
+
 import com.nostra13.universalimageloader.core.assist.LoadedFrom;
 import com.nostra13.universalimageloader.core.imageaware.ImageAware;
 
 /**
- * Just displays {@link Bitmap} in {@link com.nostra13.universalimageloader.core.imageaware.ImageAware}
- *
+ * Just displays {@link Bitmap} in
+ * {@link com.nostra13.universalimageloader.core.imageaware.ImageAware}
+ * 
  * @author Sergey Tarasevich (nostra13[at]gmail[dot]com)
  * @since 1.5.6
  */
-public final class SimpleBitmapDisplayer implements BitmapDisplayer {
+public class SimpleBitmapDisplayer implements BitmapDisplayer {
+	
+	private boolean isFirstDisplay = true;
+	
 	@Override
 	public void display(Bitmap bitmap, ImageAware imageAware, LoadedFrom loadedFrom) {
 		imageAware.setImageBitmap(bitmap);
+	}
+
+	@Override
+	public void judgeFirstDisplay(String uri, ImageAware imageAware) {
+		if (imageAware.getTag() != null && imageAware.getTag().equals(uri)) {
+			isFirstDisplay = false;
+			return ;
+		}
+		imageAware.setTag(uri);
+		isFirstDisplay = true;
+	}
+	
+	@Override
+	public boolean isFirstDisplay() {
+		return isFirstDisplay;
 	}
 }

--- a/library/src/com/nostra13/universalimageloader/core/imageaware/ImageAware.java
+++ b/library/src/com/nostra13/universalimageloader/core/imageaware/ImageAware.java
@@ -111,4 +111,8 @@ public interface ImageAware {
 	 * @return <b>true</b> if bitmap was set successfully; <b>false</b> - otherwise
 	 */
 	boolean setImageBitmap(Bitmap bitmap);
+	
+	Object getTag();
+	
+	void setTag(String uri);
 }

--- a/library/src/com/nostra13/universalimageloader/core/imageaware/NonViewAware.java
+++ b/library/src/com/nostra13/universalimageloader/core/imageaware/NonViewAware.java
@@ -19,6 +19,7 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
 import android.view.View;
+
 import com.nostra13.universalimageloader.core.assist.ImageSize;
 import com.nostra13.universalimageloader.core.assist.ViewScaleType;
 
@@ -88,5 +89,15 @@ public class NonViewAware implements ImageAware {
 	@Override
 	public boolean setImageBitmap(Bitmap bitmap) { // Do nothing
 		return true;
+	}
+
+	@Override
+	public Object getTag() {
+		return null;
+	}
+
+	@Override
+	public void setTag(String uri) {
+		
 	}
 }

--- a/library/src/com/nostra13/universalimageloader/core/imageaware/ViewAware.java
+++ b/library/src/com/nostra13/universalimageloader/core/imageaware/ViewAware.java
@@ -20,6 +20,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Looper;
 import android.view.View;
 import android.view.ViewGroup;
+
 import com.nostra13.universalimageloader.core.assist.ViewScaleType;
 import com.nostra13.universalimageloader.utils.L;
 
@@ -71,6 +72,10 @@ public abstract class ViewAware implements ImageAware {
 
 		this.viewRef = new WeakReference<View>(view);
 		this.checkActualViewSize = checkActualViewSize;
+	}
+	
+	public Reference<View> getViewRef() {
+		return this.viewRef;
 	}
 
 	/**
@@ -168,6 +173,21 @@ public abstract class ViewAware implements ImageAware {
 			L.w(WARN_CANT_SET_BITMAP);
 		}
 		return false;
+	}
+	
+	@Override
+	public void setTag(String uri) {
+		if (getViewRef().get() != null) {
+			getViewRef().get().setTag(uri);
+		}
+	}
+	
+	@Override
+	public Object getTag() {
+		if (getViewRef().get() != null) {
+			return getViewRef().get().getTag(); 
+		}
+		return "";
 	}
 
 	/**


### PR DESCRIPTION
1. Using FadeInBitmapDisplayer or some other anim BitmapDisplayer we use lots, we need to judge whether it's first display when loading more datas to avoid anim twice when adapter notification changed.
2. For this, I suggest to add two method in the interface BitmapDisplayer judgeFirstDisplay() and isFirstDisplay().  It's realize with the imageView setTag with uri  and compare. Before the displayers display,  it just need to do one more thing that is judgetFirstDisplay first. The two methods can let the users implements BitmapDisplayer and realized a new Displayer themselves and have nothing effect with the using habits.  
3. Anim BitmapDisplayer the universal-image-loader realized itself, like FadeInBitmapDisplayer can be better used without users to do a second modify.
