### PR TITLE
Updated Gradle Wrapper to 2.4 for Faster Builds

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip


### PR DESCRIPTION
http://gradle.org/docs/current/release-notes
https://gradle.org/gradle-2-4-the-fastest-yet/