### PR TITLE
Added snapshot dependency information

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Android 2.0+ support
  * **[universal-image-loader-1.9.4-with-sources.jar](https://github.com/nostra13/Android-Universal-Image-Loader/raw/master/downloads/universal-image-loader-1.9.4-with-sources.jar)** (for Eclipse)
  * [![Demo app](https://camo.githubusercontent.com/dc1ffe0e4d25c2c28a69423c3c78000ef7ee96bf/68747470733a2f2f646576656c6f7065722e616e64726f69642e636f6d2f696d616765732f6272616e642f656e5f6170705f7267625f776f5f34352e706e67)](https://play.google.com/store/apps/details?id=com.nostra13.universalimageloader.sample) [![QR Code](https://lh3.ggpht.com/csXEddxiLgQ6FxckefjQnP1PVugbaAYOdcuTa3vVtGV1PlWbFu2dYggoH8rI1w2RdEz1=w50)](http://chart.apis.google.com/chart?chs=300x300&cht=qr&chld=|1&chl=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dcom.nostra13.universalimageloader.sample) [<img src="http://mobway.in/image/apk.png" height="45px" />](https://github.com/nostra13/Android-Universal-Image-Loader/raw/master/downloads/universal-image-loader-sample-1.9.4.apk)
 
+### Snapshots
+
+You can install the latest snapshot using [JitPack](https://jitpack.io/#nostra13/Android-Universal-Image-Loader):
+
+```gradle
+repositories {
+	// ...
+	maven { url "https://jitpack.io" }
+}
+```
+and by specifying `-SNAPSHOT` as the version:
+```gradle
+dependencies {
+	compile 'com.github.nostra13:Android-Universal-Image-Loader:-SNAPSHOT'
+}
+```
+
 ## [Documentation](https://github.com/nostra13/Android-Universal-Image-Loader/wiki)
  * **[Quick Setup](https://github.com/nostra13/Android-Universal-Image-Loader/wiki/Quick-Setup)**
  * **[Configuration](https://github.com/nostra13/Android-Universal-Image-Loader/wiki/Configuration)**


### PR DESCRIPTION
Hi!

Added instructions on how to install snapshots in Gradle using the `-SNAPSHOT` syntax.
The '-SNAPSHOT' version will resolve to the latest commit.
