### PR TITLE
Fix bug OkHttpImageDownloader reports wrong values to ImageLoadingProgressListener

### DIFF
--- a/sample/src/main/java/com/nostra13/universalimageloader/sample/ext/OkHttpImageDownloader.java
+++ b/sample/src/main/java/com/nostra13/universalimageloader/sample/ext/OkHttpImageDownloader.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
  * Implementation of ImageDownloader which uses {@link com.squareup.okhttp.OkHttpClient} for image stream retrieving.
  *
  * @author Sergey Tarasevich (nostra13[at]gmail[dot]com)
+ * @author Leo Link (mr[dot]leolink[at]gmail[dot]com)
  */
 public class OkHttpImageDownloader extends BaseImageDownloader {
 
@@ -40,6 +41,9 @@ public class OkHttpImageDownloader extends BaseImageDownloader {
 	@Override
 	protected InputStream getStreamFromNetwork(String imageUri, Object extra) throws IOException {
 		Request request = new Request.Builder().url(imageUri).build();
-		return client.newCall(request).execute().body().byteStream();
+		ResponseBody responseBody = client.newCall(request).execute().body();
+		InputStream inputStream = responseBody.byteStream();
+		int contentLength = (int) responseBody.contentLength();
+		return new ContentLengthInputStream(inputStream, contentLength);
 	}
 }

--- a/sample/src/main/java/com/nostra13/universalimageloader/sample/ext/OkHttpImageDownloader.java
+++ b/sample/src/main/java/com/nostra13/universalimageloader/sample/ext/OkHttpImageDownloader.java
@@ -16,9 +16,12 @@
 package com.nostra13.universalimageloader.sample.ext;
 
 import android.content.Context;
+
+import com.nostra13.universalimageloader.core.assist.ContentLengthInputStream;
 import com.nostra13.universalimageloader.core.download.BaseImageDownloader;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.ResponseBody;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
Support contentLength for OkHttp, so ImageLoadingProgressListener's onProgressUpdate will report correct values