### PR TITLE
use ONLY one Instance options.isResetViewBeforeLoading() to hold the image in android:src="@drawable" before loading finished

### DIFF
--- a/library/src/main/java/com/nostra13/universalimageloader/core/ImageLoader.java
+++ b/library/src/main/java/com/nostra13/universalimageloader/core/ImageLoader.java
@@ -249,7 +249,7 @@ public class ImageLoader {
 			listener.onLoadingStarted(uri, imageAware.getWrappedView());
 			if (options.shouldShowImageForEmptyUri()) {
 				imageAware.setImageDrawable(options.getImageForEmptyUri(configuration.resources));
-			} else {
+			} else if (options.isResetViewBeforeLoading()) {
 				imageAware.setImageDrawable(null);
 			}
 			listener.onLoadingComplete(uri, imageAware.getWrappedView(), null);


### PR DESCRIPTION
you can set  

``` java
DisplayImageOptions.Builder.resetViewBeforeLoading(false)
```

referencing to  

``` java
builder.resetViewBeforeLoading
```
# 

Also you can use  

``` java
DisplayImageOptions.Builder.showImageOnLoading(int resId)
```

referencing to  

``` java
options.shouldShowImageOnLoading()
```

 to refuce the blank of ImageViewAwares before loading finished.  

JUST see the source.  

Thx.
