### PR TITLE
Fix problem, when InputStream always reopening instead of resetting

### DIFF
--- a/library/src/main/java/com/nostra13/universalimageloader/core/decode/BaseImageDecoder.java
+++ b/library/src/main/java/com/nostra13/universalimageloader/core/decode/BaseImageDecoder.java
@@ -22,6 +22,7 @@ import android.graphics.Matrix;
 import android.media.ExifInterface;
 import com.nostra13.universalimageloader.core.assist.ImageScaleType;
 import com.nostra13.universalimageloader.core.assist.ImageSize;
+import com.nostra13.universalimageloader.core.download.BaseImageDownloader;
 import com.nostra13.universalimageloader.core.download.ImageDownloader.Scheme;
 import com.nostra13.universalimageloader.utils.ImageSizeUtils;
 import com.nostra13.universalimageloader.utils.IoUtils;
@@ -77,6 +78,7 @@ public class BaseImageDecoder implements ImageDecoder {
 			return null;
 		}
 		try {
+			imageStream.mark(BaseImageDownloader.BUFFER_SIZE);
 			imageInfo = defineImageSizeAndRotation(imageStream, decodingInfo);
 			imageStream = resetStream(imageStream, decodingInfo);
 			Options decodingOptions = prepareDecodingOptions(imageInfo.imageSize, decodingInfo);

--- a/library/src/main/java/com/nostra13/universalimageloader/core/download/BaseImageDownloader.java
+++ b/library/src/main/java/com/nostra13/universalimageloader/core/download/BaseImageDownloader.java
@@ -56,7 +56,7 @@ public class BaseImageDownloader implements ImageDownloader {
 	public static final int DEFAULT_HTTP_READ_TIMEOUT = 20 * 1000; // milliseconds
 
 	/** {@value} */
-	protected static final int BUFFER_SIZE = 32 * 1024; // 32 Kb
+	public static final int BUFFER_SIZE = 32 * 1024; // 32 Kb
 	/** {@value} */
 	protected static final String ALLOWED_URI_CHARS = "@#&=*+-_.,:!?()/~'%";
 

--- a/sample/src/main/java/com/nostra13/universalimageloader/sample/ext/OkHttpImageDownloader.java
+++ b/sample/src/main/java/com/nostra13/universalimageloader/sample/ext/OkHttpImageDownloader.java
@@ -23,6 +23,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.ResponseBody;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -47,6 +48,6 @@ public class OkHttpImageDownloader extends BaseImageDownloader {
 		ResponseBody responseBody = client.newCall(request).execute().body();
 		InputStream inputStream = responseBody.byteStream();
 		int contentLength = (int) responseBody.contentLength();
-		return new ContentLengthInputStream(inputStream, contentLength);
+		return new ContentLengthInputStream(new BufferedInputStream(inputStream, BUFFER_SIZE), contentLength);
 	}
 }


### PR DESCRIPTION
InputStream method **reset()** works only if method **mark()** was called before reading.
Also added support to InputStream.reset() in okHttp example.
