### PR TITLE
Make circle displayer preserve aspect-ratio

### DIFF
--- a/library/src/main/java/com/nostra13/universalimageloader/core/display/CircleBitmapDisplayer.java
+++ b/library/src/main/java/com/nostra13/universalimageloader/core/display/CircleBitmapDisplayer.java
@@ -82,10 +82,14 @@ public class CircleBitmapDisplayer implements BitmapDisplayer {
 		protected float strokeRadius;
 
 		public CircleDrawable(Bitmap bitmap, Integer strokeColor, float strokeWidth) {
-			radius = Math.min(bitmap.getWidth(), bitmap.getHeight()) / 2;
+			int diameter = Math.min(bitmap.getWidth(), bitmap.getHeight());
+			radius = diameter / 2f;
 
 			bitmapShader = new BitmapShader(bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
-			mBitmapRect = new RectF(0, 0, bitmap.getWidth(), bitmap.getHeight());
+
+			float left = (bitmap.getWidth() - diameter) / 2f;
+			float top = (bitmap.getHeight() - diameter) / 2f;
+			mBitmapRect = new RectF(left, top, diameter, diameter);
 
 			paint = new Paint();
 			paint.setAntiAlias(true);


### PR DESCRIPTION
CircleBitmapDisplayer distorted non-square images to fill the ImageView.

Instead, keep the largest surface centered inside the image that preserve aspect-ratio.

**Before | After**
![auil_before_60](https://cloud.githubusercontent.com/assets/543275/18089744/bea42262-6ec1-11e6-8937-5fd6c13e6a68.png) ![auil_after_60](https://cloud.githubusercontent.com/assets/543275/18089749/c29330e8-6ec1-11e6-8bdf-47100ce292e9.png)

Compare with the original images:
[8](https://lh3.googleusercontent.com/-s-AFpvgSeew/URquc6dF-JI/AAAAAAAAAbs/Mt3xNGRUd68/s1024/Backlit%252520Cloud.jpg) [9](https://lh5.googleusercontent.com/-bvmif9a9YOQ/URquea3heHI/AAAAAAAAAbs/rcr6wyeQtAo/s1024/Bee%252520and%252520Flower.jpg) [10](https://lh5.googleusercontent.com/-n7mdm7I7FGs/URqueT_BT-I/AAAAAAAAAbs/9MYmXlmpSAo/s1024/Bonzai%252520Rock%252520Sunset.jpg) [11](https://lh6.googleusercontent.com/-4CN4X4t0M1k/URqufPozWzI/AAAAAAAAAbs/8wK41lg1KPs/s1024/Caterpillar.jpg) [12](https://lh3.googleusercontent.com/-rrFnVC8xQEg/URqufdrLBaI/AAAAAAAAAbs/s69WYy_fl1E/s1024/Chess.jpg) [13](https://lh5.googleusercontent.com/-WVpRptWH8Yw/URqugh-QmDI/AAAAAAAAAbs/E-MgBgtlUWU/s1024/Chihuly.jpg) [14](https://lh5.googleusercontent.com/-0BDXkYmckbo/URquhKFW84I/AAAAAAAAAbs/ogQtHCTk2JQ/s1024/Closed%252520Door.jpg) [15](https://lh3.googleusercontent.com/-PyggXXZRykM/URquh-kVvoI/AAAAAAAAAbs/hFtDwhtrHHQ/s1024/Colorado%252520River%252520Sunset.jpg)
