### PR TITLE
Add Gradle instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Android 2.0+ support
 **NOTE:** Use `drawable://` only if you really need it! Always **consider the native way** to load drawables - `ImageView.setImageResource(...)` instead of using of `ImageLoader`.
 
 ### Simple
+Add this to your app `build.gradle`:
+
+```
+compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
+```
+
 ``` java
 ImageLoader imageLoader = ImageLoader.getInstance(); // Get singleton instance
 ```


### PR DESCRIPTION
As a recurring user, this is the only thing I really need, and right now it's "hard" to find.

I'm used to seeing this line straight in the README.